### PR TITLE
A methodology in locate.outliers.iloop

### DIFF
--- a/R/outliers-effects.R
+++ b/R/outliers-effects.R
@@ -94,8 +94,6 @@ outliers.effects <- function(mo, n, weights = FALSE, delta = 0.7,
 
   LSeffect <- function(n, ind, w = 1)
   {
-    if (!identical(w, 1))
-      stopifnot(length(ind) == length(w))
     if (!identical(w, 1)) {
       stopifnot(length(ind) == length(w))
     } else


### PR DESCRIPTION
Hi, 

I'm using tsoutliers in my private project, so looking at how it works. 

I suspect locate.outliers.iloop is a routine for Stage I in "2.1 The detection and estimation procedure" on page 5 of Chen and Liu 1993. In Step I.2., it seems to add outliers one by one. This agrees with the first sentence of "2.2 Some Remarks on the Proposed Procedure".

But in the code, locate.outliers.iloop seems to remove multiple outliers in one go.

In a simple example below, the computation does not converge, and loop continues for a long time.
(This test is to check if tsoutliers can reproduce ARMA coeffs when apply an LS outlier at t=7000)
```
require(forecast)
n <- 10000
r <- rnorm(n, 0., 0.01)
x <- rep(0.0, n)
x[1] = r[1]

x[1] = r[1]
x[2] = x[1] + r[2]
x[3] = x[2] - 0.77 * x[1] + r[3]
for (i in 4:n){
 x[i] = x[i-1] - 0.77 * x[i-2] + 0.5 * x[i-3] + r[i]
}

require("tsoutliers")
start <- n*0.7
ls <- 0.2
for(i in start:n)
  x[i] = x[i] + ls

x <- ts(x)
arimafit <- tso(x, types = c("LS"))
arimafit
```

This is because outlier weights from outliers.tstatistics assume a single outlier in the least square estimate in Eq (13).

So I guess locate.outliers.iloop could be changed as attached.

In my change, because iloop picks up outliers one by one, the default maxiter.iloop = 4 may not be enough.
So my change accepts maxiter.iloop = NULL to for unlimited iloop.

Could you check if I'm missing something? 
